### PR TITLE
Fix deployment on other networks #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ file extension. Default directory is $projectDir/contracts. The result of the co
 printed in the console.
 Additional **--path** parameter is available, which can specify the path to the contract to be compiled.
 
+You can specify network using the **-n** or **--network** option. There are 3 options for networks predefined and available : 
+- "local" - "http://localhost:3001"
+- "testnet" - "https://sdk-testnet.aepps.com"
+- "mainnet" - "https://sdk-mainnet.aepps.com"
+
+Example:
+```
+forgae compile -n testnet
+```
+
 ## Run deploy script
 
 ```
@@ -62,7 +72,7 @@ forgae deploy
 The **deploy** command help developers run their deploy script aeternity
 proejcts. The sample deploy script is scaffolded in deployment folder.
 
-You can specify nodeUrl using the **-n** or **--network** option. There are 3 options for nodeUrls predefined and available : 
+You can specify network using the **-n** or **--network** option. There are 3 options for networks predefined and available : 
 - "local" - "http://localhost:3001"
 - "testnet" - "https://sdk-testnet.aepps.com"
 - "mainnet" - "https://sdk-mainnet.aepps.com"

--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ forgae deploy
 The **deploy** command help developers run their deploy script aeternity
 proejcts. The sample deploy script is scaffolded in deployment folder.
 
-You can specify nodeUrl using the **-n** or **--nodeUrl** option. There are 4 options for nodeUrls predefined and available : 
+You can specify nodeUrl using the **-n** or **--network** option. There are 3 options for nodeUrls predefined and available : 
 - "local" - "http://localhost:3001"
-- "edgenet" - "https://sdk-edgenet.aepps.com"
 - "testnet" - "https://sdk-testnet.aepps.com"
 - "mainnet" - "https://sdk-mainnet.aepps.com"
 

--- a/cli-commands/commands.js
+++ b/cli-commands/commands.js
@@ -40,7 +40,7 @@ const addCompileOption = (program) => {
     .option('--path [compile path]', 'Path to contract files', './contracts')
     .description('Compile contracts')
     .action(async (option) => {
-      await compile.run(option.path, option.nodeUrl);
+      await compile.run(option.path, option.network);
     })
 }
 

--- a/cli-commands/commands.js
+++ b/cli-commands/commands.js
@@ -36,7 +36,7 @@ const addInitOption = (program) => {
 const addCompileOption = (program) => {
   program
     .command('compile')
-    .option('-n --nodeUrl [nodeUrl]', 'Node to connect to', config.localhost)
+    .option('-n --network [network]', 'Network to connect to', "local")
     .option('--path [compile path]', 'Path to contract files', './contracts')
     .description('Compile contracts')
     .action(async (option) => {
@@ -83,7 +83,7 @@ const addHistoryOption = (program) => {
     .description('Show deployment history info')
     .option('--limit [limit]', 'Get last N records.', 5)
     .action(async (options) => {
-      
+
       let data = history.getHistory().slice(options.limit * -1);
 
       for (let i = 0; i < data.length; i++) {

--- a/cli-commands/forgae-compile/compile.js
+++ b/cli-commands/forgae-compile/compile.js
@@ -45,8 +45,8 @@ async function compileAndPrint(file, client) {
 
 async function run(path, network = "local") {
     print('===== Compiling contracts =====');
-    this.network = utils.getNetwork(network)
-    let client = await utils.getClient(network);
+    let currentNetwork = utils.getNetwork(network)
+    let client = await utils.getClient(currentNetwork);
 
     if (path.includes('.aes')) {
         compileAndPrint(path, client)

--- a/cli-commands/forgae-compile/compile.js
+++ b/cli-commands/forgae-compile/compile.js
@@ -43,10 +43,10 @@ async function compileAndPrint(file, client) {
     print('\r')
 }
 
-async function run(path, nodeUrl) {
+async function run(path, network = "local") {
     print('===== Compiling contracts =====');
-    
-    let client = await utils.getClient(nodeUrl);
+    this.network = utils.getNetwork(network)
+    let client = await utils.getClient(network);
 
     if (path.includes('.aes')) {
         compileAndPrint(path, client)

--- a/cli-commands/forgae-deploy/deploy.js
+++ b/cli-commands/forgae-deploy/deploy.js
@@ -27,7 +27,7 @@ const run = async (deploymentFilePath, network, secretKey) => {
 
 		console.log(`Your deployment script finished successfully!`);
 	} catch (e) {
-		console.error(e);
+		// console.error(e);
 		throw e
 	}
 };

--- a/cli-commands/forgae-deploy/deploy.js
+++ b/cli-commands/forgae-deploy/deploy.js
@@ -27,7 +27,7 @@ const run = async (deploymentFilePath, network, secretKey) => {
 
 		console.log(`Your deployment script finished successfully!`);
 	} catch (e) {
-		// console.error(e);
+		console.error(e);
 		throw e
 	}
 };

--- a/cli-commands/forgae-deploy/forgae-deployer.js
+++ b/cli-commands/forgae-deploy/forgae-deployer.js
@@ -7,7 +7,7 @@ const execute = require('./../utils').execute;
 
 logStoreService.initHistoryRecord();
 
-function getContractName (contract) {
+function getContractName(contract) {
     let rgx = /contract\s([a-zA-Z0-9]+)\s=/g;
     var match = rgx.exec(contract);
 
@@ -19,17 +19,17 @@ async function getTxInfo(txHash, network) {
     function extractUsedGas(txInfo) {
         let rgx = /Gas[_]+\s(\d+)/g;
         var match = rgx.exec(txInfo);
-    
+
         return match[1];
     }
-    
+
     function extractGasPrice(txInfo) {
         let rgx = /Gas\sPrice[_]+\s(\d+)/g
         var match = rgx.exec(txInfo);
-        
+
         return match[1];
     }
-    
+
     let result;
     try {
         result = await execute('aecli', 'inspect', [txHash, '-u', network]);
@@ -41,7 +41,7 @@ async function getTxInfo(txHash, network) {
 
         return info;
     }
-    
+
     let temp = '';
     for (const key in result) {
         if (result.hasOwnProperty(key)) {
@@ -105,11 +105,12 @@ class Deployer {
      */
     async deploy(contractPath, gas = gasLimit, initState = "") {
         let client = await utils.getClient(this.network, this.keypair);
+        console.log(this.keypair)
+        console.log(client)
         let contract = await this.readFile(contractPath);
         let deployOptions = {
             options: {
-                ttl,
-                gas
+                ttl
             },
             abi: "sophia"
         }
@@ -119,26 +120,27 @@ class Deployer {
         const compiledContract = await client.contractCompile(contract, {
             gas
         });
-
+        console.log(compiledContract)
         const deployPromise = await compiledContract.deploy(deployOptions);
         const deployedContract = await deployPromise;
-
+        console.log(deployedContract)
         let regex = new RegExp(/[\w]+.aes$/);
         let contractFileName = regex.exec(contractPath);
 
         let txInfo = await getTxInfo(deployedContract.transaction, this.network);
+        console.log(deployedContract)
         let isSuccess = false;
-        if(deployedContract.transaction) {
+        if (deployedContract.transaction) {
             isSuccess = true;
         }
-        
+
         let info = {
             deployerType: this.constructor.name,
             nameOrLabel: getContractName(contract),
             transactionHash: deployedContract.transaction,
             status: isSuccess,
-            gasPrice: txInfo.gasPrice, 
-            gasUsed: txInfo.gasUsed, 
+            gasPrice: txInfo.gasPrice,
+            gasUsed: txInfo.gasUsed,
             result: deployedContract.address
         }
 

--- a/cli-commands/forgae-deploy/forgae-deployer.js
+++ b/cli-commands/forgae-deploy/forgae-deployer.js
@@ -49,30 +49,6 @@ class Deployer {
         throw new Error("Incorrect keypair or secret key passed")
     }
 
-    // getNetwork(network) {
-    //     const networks = {
-    //         local: {
-    //             url: utils.config.localhostParams.url,
-    //             networkId: utils.config.localhostParams.networkId
-    //         },
-    //         testnet: {
-    //             url: utils.config.testnetParams.url,
-    //             networkId: utils.config.testnetParams.networkId
-    //         },
-    //         mainnet: {
-    //             url: utils.config.mainnetParams.url,
-    //             networkId: utils.config.mainnetParams.networkId
-    //         },
-    //     }
-
-    //     const result = networks[network]
-    //     if (!result) {
-    //         throw new Error(`Unrecognised network ${network}`)
-    //     }
-
-    //     return result
-    // }
-
     async readFile(path) {
         return await fs.readFileSync(path, "utf-8")
     }
@@ -89,8 +65,7 @@ class Deployer {
         let contract = await this.readFile(contractPath);
         let deployOptions = {
             options: {
-                ttl,
-                gas
+                ttl
             },
             abi: "sophia"
         }

--- a/cli-commands/forgae-init/init.js
+++ b/cli-commands/forgae-init/init.js
@@ -79,7 +79,7 @@ const installLibraries = async () => {
 
 const installAeppSDK = async (_sdkVersion = '') => {
   print('===== Installing aepp-sdk =====');
-
+  console.log(_sdkVersion)
   await execute('npm', 'install', [`@aeternity/aepp-sdk@${_sdkVersion}`, '--save-exact']);
 }
 

--- a/cli-commands/forgae-init/init.js
+++ b/cli-commands/forgae-init/init.js
@@ -79,7 +79,6 @@ const installLibraries = async () => {
 
 const installAeppSDK = async (_sdkVersion = '') => {
   print('===== Installing aepp-sdk =====');
-  console.log(_sdkVersion)
   await execute('npm', 'install', [`@aeternity/aepp-sdk@${_sdkVersion}`, '--save-exact']);
 }
 

--- a/cli-commands/forgae-node/node.js
+++ b/cli-commands/forgae-node/node.js
@@ -51,7 +51,7 @@ async function fundWallets() {
   await waitToMineCoins()
 
   let walletIndex = 0;
-  let client = await utils.getClient(config.host);
+  let client = await utils.getClient(utils.config.localhostParams);
   await printBeneficiaryKey(client);
   for (let wallet in defaultWallets) {
 
@@ -74,7 +74,7 @@ async function printWallet(client, keyPair, label) {
 }
 
 async function waitToMineCoins() {
-  let client = await utils.getClient(config.host);
+  let client = await utils.getClient(utils.config.localhostParams);
   let heightOptions = {
     interval: 8000,
     attempts: 300

--- a/cli-commands/utils.js
+++ b/cli-commands/utils.js
@@ -70,7 +70,7 @@ const getFiles = async function (directory, regex) {
         reject(new Error(error));
         return;
       }
-      
+
       files = files.filter(function (file) {
         return file.match(regex) != null;
       });
@@ -88,6 +88,9 @@ const getClient = async function (url, keypair = config.keypair) {
 
   if (url.includes("localhost")) {
     internalUrl = internalUrl + "/internal"
+  }
+  if (url.includes(config.testnetHost)) {
+    networkId = 'ae_uat'
   }
 
   if (url.includes(config.mainnetHost)) {
@@ -169,9 +172,9 @@ const readFile = async (path, encoding = null, errTitle = 'READ FILE ERR') => {
   }
 }
 
-function keyToHex (publicKey) {
-	let byteArray = Crypto.decodeBase58Check(publicKey.split('_')[1]);
-	let asHex = '0x' + byteArray.toString('hex');
+function keyToHex(publicKey) {
+  let byteArray = Crypto.decodeBase58Check(publicKey.split('_')[1]);
+  let asHex = '0x' + byteArray.toString('hex');
   return asHex;
 }
 

--- a/cli-commands/utils.js
+++ b/cli-commands/utils.js
@@ -25,10 +25,18 @@ const {
 const Universal = AeSDK.Universal;
 
 const config = {
-  localhost: "http://localhost:3001",
-  edgenetHost: "https://sdk-edgenet.aepps.com",
-  testnetHost: "https://sdk-testnet.aepps.com",
-  mainnetHost: "https://sdk-mainnet.aepps.com",
+  localhostParams: {
+    url: "http://localhost:3001",
+    networkId: 'ae_devnet'
+  },
+  testnetParams: {
+    url: "https://sdk-testnet.aepps.com",
+    networkId: 'ae_uat'
+  },
+  mainnetParams: {
+    url: 'https://sdk-mainnet.aepps.com',
+    networkId: 'ae_mainnet'
+  },
   keypair: {
     secretKey: 'bb9f0b01c8c9553cfbaf7ef81a50f977b1326801ebf7294d1c2cbccdedf27476e9bbf604e611b5460a3b3999e9771b6f60417d73ce7c5519e12f7e127a1225ca',
     publicKey: 'ak_2mwRmUeYmfuW93ti9HMSUJzCk1EYcQEfikVSzgo6k2VghsWhgU'
@@ -80,36 +88,52 @@ const getFiles = async function (directory, regex) {
   });
 }
 
-const getClient = async function (url, keypair = config.keypair) {
+const getClient = async function (network, keypair = config.keypair) {
   let client;
-  let internalUrl = url;
-  let networkId = 'ae_devnet'
+  let internalUrl = network.url;
+  console.log(network)
+  console.log(network.url)
 
-
-  if (url.includes("localhost")) {
+  if (network.url.includes("localhost")) {
     internalUrl = internalUrl + "/internal"
   }
-  if (url.includes(config.testnetHost)) {
-    networkId = 'ae_uat'
-  }
-
-  if (url.includes(config.mainnetHost)) {
-    networkId = 'ae_mainnet'
-  }
-
 
   await handleApiError(async () => {
     client = await Universal({
-      url,
+      url: network.url,
       process,
       keypair,
       internalUrl,
       nativeMode: true,
-      networkId: networkId
+      networkId: network.networkId
     })
   })
 
   return client;
+}
+
+const getNetwork = (network) => {
+  const networks = {
+    local: {
+      url: config.localhostParams.url,
+      networkId: config.localhostParams.networkId
+    },
+    testnet: {
+      url: config.testnetParams.url,
+      networkId: config.testnetParams.networkId
+    },
+    mainnet: {
+      url: config.mainnetParams.url,
+      networkId: config.mainnetParams.networkId
+    },
+  }
+
+  const result = networks[network]
+  if (!result) {
+    throw new Error(`Unrecognised network ${network}`)
+  }
+
+  return result
 }
 
 const handleApiError = async (fn) => {
@@ -211,6 +235,7 @@ module.exports = {
   copyFileOrDir,
   getFiles,
   getClient,
+  getNetwork,
   sleep,
   execute,
   readFile,

--- a/cli-commands/utils.js
+++ b/cli-commands/utils.js
@@ -91,8 +91,6 @@ const getFiles = async function (directory, regex) {
 const getClient = async function (network, keypair = config.keypair) {
   let client;
   let internalUrl = network.url;
-  console.log(network)
-  console.log(network.url)
 
   if (network.url.includes("localhost")) {
     internalUrl = internalUrl + "/internal"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,34 +9,34 @@
       "resolved": "https://registry.npmjs.org/@aeternity/aepp-sdk/-/aepp-sdk-1.0.1.tgz",
       "integrity": "sha512-akYweUqUCjLnWibO8oL04HOckETrDrna/LAgDQYorXBSDXfija3mMlsal0DMcWPtCDERdxkeYQ1KtuSVwRfNDA==",
       "requires": {
-        "@babel/runtime": "7.2.0",
-        "@stamp/it": "1.1.0",
-        "@stamp/required": "1.0.1",
-        "aes-js": "3.1.2",
-        "argon2": "0.19.3",
-        "axios": "0.18.0",
-        "bignumber.js": "8.0.1",
-        "blakejs": "1.1.0",
-        "bs58check": "2.1.2",
-        "cacache": "11.3.2",
-        "commander": "2.19.0",
-        "esm": "3.0.84",
+        "@babel/runtime": "^7.0.0-beta.46",
+        "@stamp/it": "^1.0.3",
+        "@stamp/required": "^1.0.1",
+        "aes-js": "^3.1.1",
+        "argon2": "^0.19.3",
+        "axios": "^0.18.0",
+        "bignumber.js": "^8.0.1",
+        "blakejs": "^1.1.0",
+        "bs58check": "^2.1.1",
+        "cacache": "^11.2.0",
+        "commander": "^2.14.1",
+        "esm": "^3.0.77",
         "fs": "0.0.1-security",
-        "fs-extra": "7.0.1",
-        "json-bigint": "0.3.0",
-        "path": "0.12.7",
-        "postinstall-build": "5.0.3",
-        "promisify-child-process": "2.1.2",
-        "ramda": "0.25.0",
-        "recursive-rename": "2.0.0",
-        "rlp": "2.2.1",
-        "semver": "5.6.0",
-        "serialize-javascript": "1.6.1",
-        "sha.js": "2.4.11",
-        "tweetnacl": "1.0.0",
-        "url": "0.11.0",
-        "uuid": "3.3.2",
-        "websocket": "1.0.28"
+        "fs-extra": "^7.0.0",
+        "json-bigint": "^0.3.0",
+        "path": "^0.12.7",
+        "postinstall-build": "^5.0.1",
+        "promisify-child-process": "^2.1.2",
+        "ramda": "^0.25.0",
+        "recursive-rename": "^2.0.0",
+        "rlp": "^2.0.0",
+        "semver": "^5.6.0",
+        "serialize-javascript": "^1.5.0",
+        "sha.js": "^2.4.11",
+        "tweetnacl": "^1.0.0",
+        "url": "^0.11.0",
+        "uuid": "^3.3.2",
+        "websocket": "^1.0.25"
       }
     },
     "@babel/runtime": {
@@ -44,7 +44,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
       "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
       "requires": {
-        "regenerator-runtime": "0.12.1"
+        "regenerator-runtime": "^0.12.0"
       }
     },
     "@phc/format": {
@@ -52,7 +52,7 @@
       "resolved": "https://registry.npmjs.org/@phc/format/-/format-0.4.3.tgz",
       "integrity": "sha512-UEgVMbufNOVXwTgykJ1v2q6Z2T10bfVjCxV/uYZKDI+14gMemoFOzt+4h1zyqy0QNFShP6QgsU+Sn+lRPYkaYw==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.2"
       }
     },
     "@sinonjs/commons": {
@@ -68,7 +68,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
       "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
       "requires": {
-        "@sinonjs/samsam": "3.0.2"
+        "@sinonjs/samsam": "^2 || ^3"
       }
     },
     "@sinonjs/samsam": {
@@ -76,9 +76,9 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
       "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
       "requires": {
-        "@sinonjs/commons": "1.3.0",
-        "array-from": "2.1.1",
-        "lodash.get": "4.4.2"
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
       }
     },
     "@stamp/compose": {
@@ -86,8 +86,8 @@
       "resolved": "https://registry.npmjs.org/@stamp/compose/-/compose-1.0.2.tgz",
       "integrity": "sha512-TW1/jTGesxfkFRZUNTgQ9r4Ln6YaIArZmi836o21szc8z+gxrIWrYAtI4r9LfxeD9tnTymAjB1TtvJ19OYFo3Q==",
       "requires": {
-        "@stamp/core": "1.0.1",
-        "@stamp/is": "1.0.0"
+        "@stamp/core": "^1.0.1",
+        "@stamp/is": "^1.0.0"
       }
     },
     "@stamp/core": {
@@ -95,7 +95,7 @@
       "resolved": "https://registry.npmjs.org/@stamp/core/-/core-1.0.1.tgz",
       "integrity": "sha512-oZMdU17ZgUJOHHtHXXTb4afmGKpH2kNFfXYpkd3Scs3U+1ygyqFQrpzo/F2qrnEHJOXfvBafyvA/2u4Pdm+R9g==",
       "requires": {
-        "@stamp/is": "1.0.0"
+        "@stamp/is": "^1.0.0"
       }
     },
     "@stamp/is": {
@@ -108,10 +108,10 @@
       "resolved": "https://registry.npmjs.org/@stamp/it/-/it-1.1.0.tgz",
       "integrity": "sha512-xhNHGQwPwSPm96yHpkU7DGWiKfiqhZueOvqpv8P6U0eWRVgz3bbthf9nGqjyynUmQC8S7Qekfp6IWniPHwivbg==",
       "requires": {
-        "@stamp/compose": "1.0.2",
-        "@stamp/core": "1.0.1",
-        "@stamp/is": "1.0.0",
-        "@stamp/shortcut": "1.0.2"
+        "@stamp/compose": "^1.0.2",
+        "@stamp/core": "^1.0.1",
+        "@stamp/is": "^1.0.0",
+        "@stamp/shortcut": "^1.0.2"
       }
     },
     "@stamp/required": {
@@ -119,9 +119,9 @@
       "resolved": "https://registry.npmjs.org/@stamp/required/-/required-1.0.1.tgz",
       "integrity": "sha512-LYeqXjwZ2hti6wscONrketjPNmg8x8Nis2gGQDwnyrMW97Pqv563lt/7ZmreE92dX30p9VQr7dOmN0CFrGVMmQ==",
       "requires": {
-        "@stamp/compose": "1.0.2",
-        "@stamp/core": "1.0.1",
-        "@stamp/is": "1.0.0"
+        "@stamp/compose": "^1.0.2",
+        "@stamp/core": "^1.0.1",
+        "@stamp/is": "^1.0.0"
       }
     },
     "@stamp/shortcut": {
@@ -129,7 +129,7 @@
       "resolved": "https://registry.npmjs.org/@stamp/shortcut/-/shortcut-1.0.2.tgz",
       "integrity": "sha512-waC10TO4rK/nG3YX717nqQVyVkjaH3f8bu/H0vvtCZJo8805aI5WHTefQei3G5A3vdq3nt8TDfCBqfyWXZZFSg==",
       "requires": {
-        "@stamp/compose": "1.0.2"
+        "@stamp/compose": "^1.0.2"
       }
     },
     "@types/blue-tape": {
@@ -137,8 +137,8 @@
       "resolved": "https://registry.npmjs.org/@types/blue-tape/-/blue-tape-0.1.32.tgz",
       "integrity": "sha512-2kWAlqlSdq0ySnjVM7rxX9t9pnNYaCqFf23uRZf6kHc/YZDKbwgIBNww2YbW9EfIKuG710VTczkMNvkSL7ldSQ==",
       "requires": {
-        "@types/node": "10.12.18",
-        "@types/tape": "4.2.33"
+        "@types/node": "*",
+        "@types/tape": "*"
       }
     },
     "@types/lodash": {
@@ -156,7 +156,7 @@
       "resolved": "https://registry.npmjs.org/@types/tape/-/tape-4.2.33.tgz",
       "integrity": "sha512-ltfyuY5BIkYlGuQfwqzTDT8f0q8Z5DGppvUnWGs39oqDmMd6/UWhNpX3ZMh/VYvfxs3rFGHMrLC/eGRdLiDGuw==",
       "requires": {
-        "@types/node": "10.12.18"
+        "@types/node": "*"
       }
     },
     "aes-js": {
@@ -169,7 +169,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "any-promise": {
@@ -187,10 +187,10 @@
       "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.19.3.tgz",
       "integrity": "sha1-TlnLO89dHwnKB7RScWM0Zw75oLc=",
       "requires": {
-        "@phc/format": "0.4.3",
-        "any-promise": "1.3.0",
-        "bindings": "1.3.1",
-        "nan": "2.12.1"
+        "@phc/format": "^0.4.2",
+        "any-promise": "^1.3.0",
+        "bindings": "^1.3.0",
+        "nan": "^2.10.0"
       }
     },
     "array-from": {
@@ -208,7 +208,7 @@
       "resolved": "https://registry.npmjs.org/await-spawn/-/await-spawn-2.1.2.tgz",
       "integrity": "sha512-GGmJE5G36WRCIkWwF6weHmdIjiW5elsv2SBJNp4jYD4EB23iPQzmuahfTSgYQGuMSorh3Xcc1QNbDyidqlrJ/w==",
       "requires": {
-        "bl": "2.1.2"
+        "bl": "^2.0.0"
       }
     },
     "axios": {
@@ -216,8 +216,8 @@
       "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.6.1",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "babel-runtime": {
@@ -225,8 +225,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.6.1",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -246,7 +246,7 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
       "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "bignumber.js": {
@@ -264,8 +264,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.1.2.tgz",
       "integrity": "sha512-DvC0x+PxmSJNx8wXoFV15pC2+GOJ3ohb4F1REq3X32a2Z3nEBpR1Guu740M7ouYAImFj4BXDNilLNZbygtG9lQ==",
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "blakejs": {
@@ -283,7 +283,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -297,7 +297,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
-        "base-x": "3.0.5"
+        "base-x": "^3.0.2"
       }
     },
     "bs58check": {
@@ -305,9 +305,9 @@
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "requires": {
-        "bs58": "4.0.1",
-        "create-hash": "1.2.0",
-        "safe-buffer": "5.1.2"
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "buffer-from": {
@@ -320,20 +320,20 @@
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
       "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
       "requires": {
-        "bluebird": "3.5.3",
-        "chownr": "1.1.1",
-        "figgy-pudding": "3.5.1",
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.15",
-        "lru-cache": "5.1.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.3",
-        "ssri": "6.0.1",
-        "unique-filename": "1.1.1",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.3",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
       }
     },
     "chai": {
@@ -341,12 +341,12 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chai-as-promised": {
@@ -354,7 +354,7 @@
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "requires": {
-        "check-error": "1.0.2"
+        "check-error": "^1.0.2"
       }
     },
     "chai-files": {
@@ -362,7 +362,7 @@
       "resolved": "https://registry.npmjs.org/chai-files/-/chai-files-1.4.0.tgz",
       "integrity": "sha1-DiVhD63FUbHq55wvTuefry+EIpY=",
       "requires": {
-        "assertion-error": "1.1.0"
+        "assertion-error": "^1.0.1"
       }
     },
     "chalk": {
@@ -370,9 +370,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "check-error": {
@@ -390,8 +390,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cli-table": {
@@ -414,7 +414,7 @@
       "resolved": "https://registry.npmjs.org/cli-table-2-json/-/cli-table-2-json-1.0.11.tgz",
       "integrity": "sha512-mTyVEzqS1Y1Uv1LcUnRnXd26eRdn7Os1/dAfQswzTC/BHytXha5freTe8293Uz8i49lz3JG2Z5sWfxLS6UPjSg==",
       "requires": {
-        "@types/blue-tape": "0.1.32",
+        "@types/blue-tape": "^0.1.30",
         "@types/lodash": "4.14.116",
         "lodash": "4.17.10"
       }
@@ -452,10 +452,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "copy-concurrently": {
@@ -463,12 +463,12 @@
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.3",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "core-js": {
@@ -486,11 +486,11 @@
       "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.5",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "cyclist": {
@@ -511,7 +511,7 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "diff": {
@@ -545,9 +545,9 @@
           "resolved": "https://registry.npmjs.org/cli-table-2-json/-/cli-table-2-json-1.0.10.tgz",
           "integrity": "sha1-m6iWAlbHAy79EKP2K+PF6WuvmCI=",
           "requires": {
-            "@types/blue-tape": "0.1.32",
-            "@types/lodash": "4.14.116",
-            "lodash": "4.17.10"
+            "@types/blue-tape": "^0.1.30",
+            "@types/lodash": "^4.14.64",
+            "lodash": "^4.12.0"
           }
         }
       }
@@ -562,10 +562,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
       "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "end-of-stream": {
@@ -573,7 +573,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "escape-string-regexp": {
@@ -596,8 +596,8 @@
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "follow-redirects": {
@@ -605,7 +605,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
       "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "=3.1.0"
       }
     },
     "from2": {
@@ -613,8 +613,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs": {
@@ -627,9 +627,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
-        "graceful-fs": "4.1.15",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -637,10 +637,10 @@
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "requires": {
-        "graceful-fs": "4.1.15",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -658,12 +658,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "global": {
@@ -671,8 +671,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       },
       "dependencies": {
         "process": {
@@ -702,8 +702,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "he": {
@@ -726,8 +726,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -760,7 +760,7 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
       "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
       "requires": {
-        "bignumber.js": "7.2.1"
+        "bignumber.js": "^7.0.0"
       },
       "dependencies": {
         "bignumber.js": {
@@ -775,7 +775,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.15"
+        "graceful-fs": "^4.1.6"
       }
     },
     "just-extend": {
@@ -803,7 +803,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
-        "yallist": "3.0.3"
+        "yallist": "^3.0.2"
       }
     },
     "md5.js": {
@@ -811,9 +811,9 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "min-document": {
@@ -821,7 +821,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimatch": {
@@ -829,7 +829,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -842,16 +842,16 @@
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexify": "3.6.1",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.0.3",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "3.0.0",
-        "pumpify": "1.5.1",
-        "stream-each": "1.2.3",
-        "through2": "2.0.5"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mkdirp": {
@@ -890,12 +890,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -910,12 +910,12 @@
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.3",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -933,11 +933,11 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
       "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
       "requires": {
-        "@sinonjs/formatio": "3.1.0",
-        "just-extend": "4.0.2",
-        "lolex": "2.7.5",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       },
       "dependencies": {
         "lolex": {
@@ -952,7 +952,7 @@
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.2"
       }
     },
     "nodeify-ts": {
@@ -965,7 +965,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "original-require": {
@@ -978,9 +978,9 @@
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "path": {
@@ -988,8 +988,8 @@
       "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
       "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
       "requires": {
-        "process": "0.11.10",
-        "util": "0.10.4"
+        "process": "^0.11.1",
+        "util": "^0.10.3"
       }
     },
     "path-is-absolute": {
@@ -1047,7 +1047,7 @@
       "resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-2.1.2.tgz",
       "integrity": "sha512-j2BRwNaM7fUwrd67avtqSTRevQXZiqS+T4Ky3VVaQdvzkPpsTByBAv+ZyBxuXgV/eUrCe2qYrOZvPvd+sMryeg==",
       "requires": {
-        "@types/node": "10.12.18"
+        "@types/node": "^10.11.3"
       }
     },
     "pump": {
@@ -1055,8 +1055,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -1064,9 +1064,9 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
-        "duplexify": "3.6.1",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       },
       "dependencies": {
         "pump": {
@@ -1074,8 +1074,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -1100,13 +1100,13 @@
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "rechoir": {
@@ -1114,7 +1114,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.9.0"
+        "resolve": "^1.1.6"
       }
     },
     "recursive-rename": {
@@ -1122,11 +1122,11 @@
       "resolved": "https://registry.npmjs.org/recursive-rename/-/recursive-rename-2.0.0.tgz",
       "integrity": "sha1-da66Q08kJk1QjR2Dr5U9iYknMec=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "bluebird": "3.5.3",
-        "colors": "1.3.3",
-        "global": "4.3.2",
-        "minimist": "1.2.0"
+        "babel-runtime": "^6.23.0",
+        "bluebird": "^3.5.0",
+        "colors": "^1.1.2",
+        "global": "^4.3.2",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -1146,7 +1146,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
       "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "rimraf": {
@@ -1154,7 +1154,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.1.3"
       }
     },
     "ripemd160": {
@@ -1162,8 +1162,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rlp": {
@@ -1171,7 +1171,7 @@
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.1.tgz",
       "integrity": "sha512-nqB/qy+YjXdp/zj1CjCiDwfLMBPv/XFDol0ir/7O/+Ix90++rvi+QoK1CDJcn8JoqCu2WrPPeRucu4qyIDzALg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.1"
       }
     },
     "run-queue": {
@@ -1179,7 +1179,7 @@
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "safe-buffer": {
@@ -1202,8 +1202,8 @@
       "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shelljs": {
@@ -1211,9 +1211,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
       "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
       "requires": {
-        "glob": "7.1.3",
-        "interpret": "1.2.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "sinon": {
@@ -1221,13 +1221,13 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.2.tgz",
       "integrity": "sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==",
       "requires": {
-        "@sinonjs/commons": "1.3.0",
-        "@sinonjs/formatio": "3.1.0",
-        "@sinonjs/samsam": "3.0.2",
-        "diff": "3.5.0",
-        "lolex": "3.0.0",
-        "nise": "1.4.8",
-        "supports-color": "5.5.0"
+        "@sinonjs/commons": "^1.2.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.2",
+        "diff": "^3.5.0",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.7",
+        "supports-color": "^5.5.0"
       },
       "dependencies": {
         "supports-color": {
@@ -1235,7 +1235,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1245,7 +1245,7 @@
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "requires": {
-        "figgy-pudding": "3.5.1"
+        "figgy-pudding": "^3.5.1"
       }
     },
     "stream-each": {
@@ -1253,8 +1253,8 @@
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-shift": {
@@ -1267,7 +1267,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "supports-color": {
@@ -1275,7 +1275,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "text-encoding": {
@@ -1288,8 +1288,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
     "tweetnacl": {
@@ -1312,7 +1312,7 @@
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
-        "is-typedarray": "1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "unique-filename": {
@@ -1320,7 +1320,7 @@
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "requires": {
-        "unique-slug": "2.0.1"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -1328,7 +1328,7 @@
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
       "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "universalify": {
@@ -1368,10 +1368,10 @@
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
       "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
       "requires": {
-        "debug": "2.6.9",
-        "nan": "2.12.1",
-        "typedarray-to-buffer": "3.1.5",
-        "yaeti": "0.0.6"
+        "debug": "^2.2.0",
+        "nan": "^2.11.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
       },
       "dependencies": {
         "debug": {

--- a/test/commands-tests/compile.js
+++ b/test/commands-tests/compile.js
@@ -45,8 +45,8 @@ describe('ForgAE Compile', () => {
 			assert.include(result, expectedCompileResultExampleContract)
 		})
 
-		it('Should compile contracts with nodeUrl argument - edgenet ', async () => {
-			let result = await execute(constants.cliCommands.COMPILE, ["-n", "https://sdk-edgenet.aepps.com"], executeOptions)
+		it('Should compile contracts with nodeUrl argument - testnet ', async () => {
+			let result = await execute(constants.cliCommands.COMPILE, ["-n", "https://sdk-testnet.aepps.com"], executeOptions)
 
 			assert.include(result, expectedCompileResultExampleContract)
 		})

--- a/test/commands-tests/compile.js
+++ b/test/commands-tests/compile.js
@@ -39,14 +39,36 @@ describe('ForgAE Compile', () => {
 			assert.include(result, expectedResult3)
 		})
 
-		it('Should compile contracts with nodeUrl argument - localhost', async () => {
-			let result = await execute(constants.cliCommands.COMPILE, ["-n", "http://localhost:3001"], executeOptions)
+		it('Should compile contracts with -n argument - localhost', async () => {
+			let result = await execute(constants.cliCommands.COMPILE, ["-n", "local"], executeOptions)
 
 			assert.include(result, expectedCompileResultExampleContract)
 		})
 
-		it('Should compile contracts with nodeUrl argument - testnet ', async () => {
-			let result = await execute(constants.cliCommands.COMPILE, ["-n", "https://sdk-testnet.aepps.com"], executeOptions)
+		it('Should compile contracts with -n argument - testnet ', async () => {
+			let result = await execute(constants.cliCommands.COMPILE, ["-n", "testnet"], executeOptions)
+
+			assert.include(result, expectedCompileResultExampleContract)
+		})
+		it('Should compile contracts with -n argument - mainnet ', async () => {
+			let result = await execute(constants.cliCommands.COMPILE, ["-n", "mainnet"], executeOptions)
+
+			assert.include(result, expectedCompileResultExampleContract)
+		})
+
+		it('Should compile contracts with --network argument - localhost', async () => {
+			let result = await execute(constants.cliCommands.COMPILE, ["--network", "local"], executeOptions)
+
+			assert.include(result, expectedCompileResultExampleContract)
+		})
+
+		it('Should compile contracts with --network argument - testnet ', async () => {
+			let result = await execute(constants.cliCommands.COMPILE, ["--network", "testnet"], executeOptions)
+
+			assert.include(result, expectedCompileResultExampleContract)
+		})
+		it('Should compile contracts with --netwotk argument - mainnet ', async () => {
+			let result = await execute(constants.cliCommands.COMPILE, ["--network", "mainnet"], executeOptions)
 
 			assert.include(result, expectedCompileResultExampleContract)
 		})

--- a/test/commands-tests/deploy.js
+++ b/test/commands-tests/deploy.js
@@ -32,18 +32,6 @@ describe('ForgAE Deploy', () => {
 			assert.equal(deployer.network, expectedNetwork)
 		})
 
-		it('Should init Deployer with edgenet network', async () => {
-			//Arrange
-			const expectedNetwork = "https://sdk-edgenet.aepps.com"
-			const passedNetwork = "edgenet"
-
-			//Act
-			const deployer = new Deployer(passedNetwork);
-
-			//Assert
-			assert.equal(deployer.network, expectedNetwork)
-		})
-
 		it('Should init Deployer with testnet network', async () => {
 			//Arrange
 			const expectedNetwork = "https://sdk-testnet.aepps.com"
@@ -140,6 +128,14 @@ describe('ForgAE Deploy', () => {
 
 			assert.include(result, expectedDeployResult)
 		})
+
+		it('with network and secret on test networ', async () => {
+			let testSecretKey = "123a422a7d60a14559f65d64e1762cce04706844d8249e9ca708a4f6d99c8aed3c95e234526e2baec1f800ffc979b3fea0e2006a5336aa66fab7f17ec0e3b319"
+			let result = await execute(constants.cliCommands.DEPLOY, ["-n", "testnet", "-s", testSecretKey], executeOptions)
+
+			assert.include(result, expectedDeployResult)
+		})
+
 
 		it('with invalid network arguments', async () => {
 			let executePromise = execute(constants.cliCommands.DEPLOY, ["-n", "public"], executeOptions)

--- a/test/commands-tests/deploy.js
+++ b/test/commands-tests/deploy.js
@@ -29,7 +29,7 @@ describe('ForgAE Deploy', () => {
 			const deployer = new Deployer(passedNetwork);
 
 			//Assert
-			assert.equal(deployer.network, expectedNetwork)
+			assert.equal(deployer.network.url, expectedNetwork)
 		})
 
 		it('Should init Deployer with testnet network', async () => {
@@ -41,7 +41,7 @@ describe('ForgAE Deploy', () => {
 			const deployer = new Deployer(passedNetwork);
 
 			//Assert
-			assert.equal(deployer.network, expectedNetwork)
+			assert.equal(deployer.network.url, expectedNetwork)
 		})
 
 		it('Should init Deployer with mainnet network', async () => {
@@ -53,7 +53,7 @@ describe('ForgAE Deploy', () => {
 			const deployer = new Deployer(passedNetwork);
 
 			//Assert
-			assert.equal(deployer.network, expectedNetwork)
+			assert.equal(deployer.network.url, expectedNetwork)
 		})
 
 		it('Should deploy contract with init arguments', async () => {
@@ -129,7 +129,7 @@ describe('ForgAE Deploy', () => {
 			assert.include(result, expectedDeployResult)
 		})
 
-		it('with network and secret on test networ', async () => {
+		it('with network and secret on test network', async () => {
 			let testSecretKey = "123a422a7d60a14559f65d64e1762cce04706844d8249e9ca708a4f6d99c8aed3c95e234526e2baec1f800ffc979b3fea0e2006a5336aa66fab7f17ec0e3b319"
 			let result = await execute(constants.cliCommands.DEPLOY, ["-n", "testnet", "-s", testSecretKey], executeOptions)
 


### PR DESCRIPTION
Fix deployment on testnet (uat).
Remove edgenet from the predefined networks, because it is outdated and will be shut down in near future.

Code refactoring for more readability, also small changes to compile command for consistency with the deploy command

closes #54 